### PR TITLE
Update airship-rest.js

### DIFF
--- a/rest/airship-rest.js
+++ b/rest/airship-rest.js
@@ -96,6 +96,9 @@ module.exports = function (RED) {
                 case 'production':
                     baseUrl = 'https://api.airship.co.uk/';
                     break;
+		case 'fake-api':
+                    baseUrl = 'https://fake-api.airship.co.uk/';
+                    break;
                 default:
                     baseUrl = 'https://api.airship.co.uk/';
             }


### PR DESCRIPTION
Added the fake api option so we can post REST payloads to a system which logs the payloads rather than processes them. This allows us to test at a much faster speed.