### PR TITLE
make node usable with aws lambda endpoint

### DIFF
--- a/libs/axios.js
+++ b/libs/axios.js
@@ -26,11 +26,21 @@ const httpsKeepAliveAgent = new HttpsAgent({
  * @param  {[json]}   payload     [payload]
  * @return {[promise]}        
  */
-function call(url, httpMethod, payload){
+function call(url, httpMethod, payload, ingestMethod, AWSKey){
 
 return new Promise((resolve, reject) => {
     
         if ((payload.contact || payload.body) && payload.token) {
+
+            let headers = {
+                'Authorization': 'Bearer ' + payload.token,
+                'content-type': 'application/json' 
+            }
+
+            if (ingestMethod === 'AWS') {
+                headers['X-Integration-Auth'] = AWSKey;
+            }
+
             try {
                axios({
                     httpAgent: keepAliveAgent,
@@ -38,10 +48,7 @@ return new Promise((resolve, reject) => {
                     method: httpMethod,
                     url: url,
                     responseType: 'json',
-                    headers: {
-                        'Authorization': 'Bearer ' + payload.token,
-                        'content-type': 'application/json' 
-                    },
+                    headers: headers,
                     data: payload.contact ? payload.contact : payload.body
                 })
                 .then((response) => {

--- a/rest/airship-rest.html
+++ b/rest/airship-rest.html
@@ -9,6 +9,8 @@
         defaults: {
             name:    { value: "" },
             version: { value: "" },
+            ingestMethod: { value: "" },
+            AWSKey:  { value: "" },
             method:  { value: "" },
             env:     { value: "" }
         },
@@ -57,6 +59,20 @@
             </optgroup>
         </select>
     </div>
+
+    <div class="form-row">
+        <label for="node-input-ingestMethod"><i class="fa fa-tag"></i> Data Ingest method</label>
+        <select id="node-input-ingestMethod">
+            <option value="">Select Data Ingest Method</option>
+            <option value="REST">REST</option>
+            <option value="AWS">AWS</option>
+        </select>
+    </div>
+
+    <div class="form-row">
+        <label for="node-input-AWSKey"><i class="fa fa-tag"></i> AWS Key</label>
+        <input type="text" id="node-input-AWSKey" placeholder="AWS Key">
+    </div>
    
 </script>
 
@@ -101,6 +117,11 @@ env:'dev', // can be passed here to select dev, staging or production (default)
 method:'contact', // can either be passed in here, or selected in the dropdown of the node
 
 httpMethod:'POST', // can either be passed in here or automatically selected by chosen option on dropdown
+
+ingestMethod:'REST', // can either be passed in here or automatically selected by chosen option on dropdown
+
+AWSKey:'', // can either be passed in here or automatically or inserted in the node config
+
     </pre>
 
     <h3>Outputs:</h3>

--- a/rest/airship-rest.html
+++ b/rest/airship-rest.html
@@ -118,9 +118,9 @@ method:'contact', // can either be passed in here, or selected in the dropdown o
 
 httpMethod:'POST', // can either be passed in here or automatically selected by chosen option on dropdown
 
-ingestMethod:'REST', // can either be passed in here or automatically selected by chosen option on dropdown
+ingestMethod:'REST', // can either be passed in here or on the msg object
 
-AWSKey:'', // can either be passed in here or automatically or inserted in the node config
+AWSKey:'', // can either be passed in here or on the msg object
 
     </pre>
 

--- a/rest/airship-rest.js
+++ b/rest/airship-rest.js
@@ -10,6 +10,8 @@ module.exports = function (RED) {
 		this.method  = n.method;
 		this.payload = n.payload;
         this.version = n.version;
+        this.ingestMethod = n.ingestMethod;
+        this.AWSKey = n.AWSKey;
         this.env = n.env;
         this.status({});
         
@@ -137,7 +139,7 @@ module.exports = function (RED) {
 		 * @param  {[object]} payload [payload to be send to node]
 		 * @param  {[object]} msg [msg to be passed on]
 		 */
-        this.restCall = async function (url, httpMethod, payload, msg) {
+        this.restCall = async function (url, httpMethod, payload, msg, ingestMethod, AWSKey) {
             let body = 
                 payload.contact ? payload.contact :
                 payload.body ? payload.body :
@@ -147,7 +149,7 @@ module.exports = function (RED) {
                 this.sendError(msg, "No body or contact found on request", body, true);
             }
             else {
-                await axios.call(url, httpMethod, payload).then((res) => {
+                await axios.call(url, httpMethod, payload, ingestMethod, AWSKey).then((res) => {
                         this.sendSuccess(msg, res, body);
                     }).catch((err) => {
                         this.sendError(msg, err, body);
@@ -163,6 +165,8 @@ module.exports = function (RED) {
             let method      = msg.method ? msg.method : this.method;
             let httpMethod  = msg.httpMethod ? msg.httpMethod : this.httpMethod(method);
             let version     = msg.version ? msg.version : this.version;
+            let ingestMethod= msg.ingestMethod ? msg.ingestMethod : this.ingestMethod;
+            let AWSKey      = msg.AWSKey ? msg.AWSKey : this.AWSKey;
             let payload     = msg.payload ? msg.payload : this.payload;
             let env         = msg.env ? msg.env : this.env;
 
@@ -180,13 +184,19 @@ module.exports = function (RED) {
                         baseUrl = 'https://api-airshipdev.airship.co.uk/';
                         break;
                     case 'production':
-                        baseUrl = 'https://api.airship.co.uk/';
+                        if(ingestMethod === 'AWS')
+                            baseUrl = 'https://data-ingest.airship-api.com/';
+                        else
+                            baseUrl = 'https://api.airship.co.uk/';
                         break;
                     case 'fake-api':
                         baseUrl = 'https://fake-api.airship.co.uk/';
                         break;
                     default:
-                        baseUrl = 'https://api.airship.co.uk/';
+                        if(ingestMethod === 'AWS')
+                            baseUrl = 'https://data-ingest.airship-api.com/';
+                        else
+                            baseUrl = 'https://api.airship.co.uk/';
                 }
 
                 // correct REST method in case it's a dual name
@@ -200,7 +210,7 @@ module.exports = function (RED) {
                     airshipvalidation.validate(payload.contact).then((invalidFields) => {
                         if (invalidFields) msg.invalidFields = invalidFields;
 
-                        this.restCall(url, httpMethod, payload, msg);
+                        this.restCall(url, httpMethod, payload, msg, ingestMethod, AWSKey);
 
                     }).catch((err) => {
                         this.showstatus("yellow", "dot", "validation error");
@@ -209,7 +219,7 @@ module.exports = function (RED) {
 
                 } else {
                     //Backwards compatibility / general methods that uses msg.payload.body instead of contact
-                    this.restCall(url, httpMethod, payload, msg);
+                    this.restCall(url, httpMethod, payload, msg, ingestMethod, AWSKey);
                 }
             }
 	    });

--- a/rest/airship-rest.js
+++ b/rest/airship-rest.js
@@ -203,6 +203,11 @@ module.exports = function (RED) {
                 if (method === 'post_bookings' || method === 'get_bookings') method = 'bookings';
                 let url = baseUrl + version + "/" + method;
 
+                // Check if AWS Key is set if ingest method is AWS
+                if (ingestMethod === 'AWS' && !AWSKey) {
+                    this.sendError(msg, "AWS Key must be set on REST node or passed on msg object", payload.contact, true);
+                    return;
+                }
 
                 // Set contact if is passed
                 if (payload.contact && httpMethod === 'POST' ) {


### PR DESCRIPTION
Modify REST node to use AWS async endpoint and include auth header, options for both can be configured on the node within node-red