### PR TITLE
176_QA_update_rest_node: added more error handling, custom node confi…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-airship-rest",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "description": "Airship REST API node red library",
   "repository": {
     "type": "git",

--- a/rest/airship-rest.js
+++ b/rest/airship-rest.js
@@ -160,7 +160,7 @@ module.exports = function (RED) {
         this.on('input',  (msg) => {
 
             try {
-                if (!msg.ingestMethod || !this.ingestMethod)
+                if (!msg.ingestMethod && !this.ingestMethod)
                     throw new Error("ingestMethod property not provided. Set `msg.ingestMethod` or set it on the node configuration");
 
                 this.showstatus("yellow","dot","Making call");

--- a/rest/airship-rest.js
+++ b/rest/airship-rest.js
@@ -232,7 +232,7 @@ module.exports = function (RED) {
                     }
                 }
             } catch (err) {
-                this.sendError(msg, err, this.payload.contact, true);
+                this.sendError(msg, err, null, true);
             }
 	    });
      

--- a/rest/airship-rest.js
+++ b/rest/airship-rest.js
@@ -159,73 +159,80 @@ module.exports = function (RED) {
 
         this.on('input',  (msg) => {
 
-        	this.showstatus("yellow","dot","Making call");
+            try {
+                if (!msg.ingestMethod || !this.ingestMethod)
+                    throw new Error("ingestMethod property not provided. Set `msg.ingestMethod` or set it on the node configuration");
 
-            //set variables
-            let method      = msg.method ? msg.method : this.method;
-            let httpMethod  = msg.httpMethod ? msg.httpMethod : this.httpMethod(method);
-            let version     = msg.version ? msg.version : this.version;
-            let ingestMethod= msg.ingestMethod ? msg.ingestMethod : this.ingestMethod;
-            let AWSKey      = msg.AWSKey ? msg.AWSKey : this.AWSKey;
-            let payload     = msg.payload ? msg.payload : this.payload;
-            let env         = msg.env ? msg.env : this.env;
-
-            if (msg.config === null || msg.config === undefined) {
-                this.sendError(msg, "Config property not found on message", null, true);
-            } else {
-
-                // build URL
-                let baseUrl = '';
-                switch(env){
-                    case 'dev':
-                        baseUrl = 'https://api-dev.airship.co.uk/';
-                        break;
-                    case 'staging':
-                        baseUrl = 'https://api-airshipdev.airship.co.uk/';
-                        break;
-                    case 'production':
-                        if(ingestMethod === 'AWS')
-                            baseUrl = 'https://data-ingest.airship-api.com/';
-                        else
-                            baseUrl = 'https://api.airship.co.uk/';
-                        break;
-                    case 'fake-api':
-                        baseUrl = 'https://fake-api.airship.co.uk/';
-                        break;
-                    default:
-                        if(ingestMethod === 'AWS')
-                            baseUrl = 'https://data-ingest.airship-api.com/';
-                        else
-                            baseUrl = 'https://api.airship.co.uk/';
-                }
-
-                // correct REST method in case it's a dual name
-                if (method === 'post_bookings' || method === 'get_bookings') method = 'bookings';
-                let url = baseUrl + version + "/" + method;
-
-                // Check if AWS Key is set if ingest method is AWS
-                if (ingestMethod === 'AWS' && !AWSKey) {
-                    this.sendError(msg, "AWS Key must be set on REST node or passed on msg object", payload.contact, true);
-                    return;
-                }
-
-                // Set contact if is passed
-                if (payload.contact && httpMethod === 'POST' ) {
-
-                    airshipvalidation.validate(payload.contact).then((invalidFields) => {
-                        if (invalidFields) msg.invalidFields = invalidFields;
-
-                        this.restCall(url, httpMethod, payload, msg, ingestMethod, AWSKey);
-
-                    }).catch((err) => {
-                        this.showstatus("yellow", "dot", "validation error");
-                        this.send([null, this.outputToMonitor(msg, payload.contact, false, err), null]);
-                    });
-
+                this.showstatus("yellow","dot","Making call");
+                
+                //set variables
+                let method      = msg.method ? msg.method : this.method;
+                let httpMethod  = msg.httpMethod ? msg.httpMethod : this.httpMethod(method);
+                let version     = msg.version ? msg.version : this.version;
+                let ingestMethod= this.ingestMethod ? this.ingestMethod : msg.ingestMethod;
+                let AWSKey      = msg.AWSKey ? msg.AWSKey : this.AWSKey;
+                let payload     = msg.payload ? msg.payload : this.payload;
+                let env         = msg.env ? msg.env : this.env;
+    
+                if (msg.config === null || msg.config === undefined) {
+                    this.sendError(msg, "Config property not found on message", null, true);
                 } else {
-                    //Backwards compatibility / general methods that uses msg.payload.body instead of contact
-                    this.restCall(url, httpMethod, payload, msg, ingestMethod, AWSKey);
+    
+                    // build URL
+                    let baseUrl = '';
+                    switch(env){
+                        case 'dev':
+                            baseUrl = 'https://api-dev.airship.co.uk/';
+                            break;
+                        case 'staging':
+                            baseUrl = 'https://api-airshipdev.airship.co.uk/';
+                            break;
+                        case 'production':
+                            if(ingestMethod === 'AWS')
+                                baseUrl = 'https://data-ingest.airship-api.com/';
+                            else
+                                baseUrl = 'https://api.airship.co.uk/';
+                            break;
+                        case 'fake-api':
+                            baseUrl = 'https://fake-api.airship.co.uk/';
+                            break;
+                        default:
+                            if(ingestMethod === 'AWS')
+                                baseUrl = 'https://data-ingest.airship-api.com/';
+                            else
+                                baseUrl = 'https://api.airship.co.uk/';
+                    }
+    
+                    // correct REST method in case it's a dual name
+                    if (method === 'post_bookings' || method === 'get_bookings') method = 'bookings';
+                    let url = baseUrl + version + "/" + method;
+    
+                    // Check if AWS Key is set if ingest method is AWS
+                    if (ingestMethod === 'AWS' && !AWSKey) {
+                        this.sendError(msg, "AWS Key must be set on REST node or passed on msg object", payload.contact, true);
+                        return;
+                    }
+    
+                    // Set contact if is passed
+                    if (payload.contact && httpMethod === 'POST' ) {
+    
+                        airshipvalidation.validate(payload.contact).then((invalidFields) => {
+                            if (invalidFields) msg.invalidFields = invalidFields;
+    
+                            this.restCall(url, httpMethod, payload, msg, ingestMethod, AWSKey);
+    
+                        }).catch((err) => {
+                            this.showstatus("yellow", "dot", "validation error");
+                            this.send([null, this.outputToMonitor(msg, payload.contact, false, err), null]);
+                        });
+    
+                    } else {
+                        //Backwards compatibility / general methods that uses msg.payload.body instead of contact
+                        this.restCall(url, httpMethod, payload, msg, ingestMethod, AWSKey);
+                    }
                 }
+            } catch (err) {
+                this.sendError(msg, err, this.payload.contact, true);
             }
 	    });
      


### PR DESCRIPTION
msg object was overwriting the custom nodes configured value: Setting the value in the nodes configuration now takes precedence over the message object.

error handling for when neither payload or node configuration has `ingestMethod` set